### PR TITLE
Make Initial Alembic Migration

### DIFF
--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -43,6 +43,8 @@ Sync models from this application to the newly created database:
 
     .. code-block:: shell
 
+        ws-alembic -c {{ cookiecutter.namespace }}/{{ cookiecutter.package_name }}/conf/development.ini -x packages=all revision --auto -m "Initial migration"
+        ws-alembic -c {{ cookiecutter.namespace }}/{{ cookiecutter.package_name }}/conf/development.ini -x packages=all upgrade head
         ws-sync-db {{ cookiecutter.namespace }}/{{ cookiecutter.package_name }}/conf/development.ini
 
 


### PR DESCRIPTION
`ws-sync-db` does not create alembic migrations to recreate the base tables. Without initial revision and upgrade, subsequent revisions will not generate 'create statements' resulting in changes being made to non-existent tables.